### PR TITLE
Update bridge config for latest rpc changes

### DIFF
--- a/upgradable-wo-parity/DETAILS.md
+++ b/upgradable-wo-parity/DETAILS.md
@@ -97,7 +97,7 @@ WantedBy=multi-user.target
 ```
 By default, restart delay is 3 seconds, this can be controlled by `restart_delay_sec` variable
 
-5. Logs are stored in `/var/log/syslog`
+5. Logs are stored in `/var/log/syslog`. If you provided `syslog_server_port` variable (in format `host:port`) in `hosts.yml` during installation, logs from syslog will be duplicated to a central syslog server for analysis and monitoring
 
 ## Useful commands
 1. Restart services:

--- a/upgradable-wo-parity/DETAILS.md
+++ b/upgradable-wo-parity/DETAILS.md
@@ -13,19 +13,16 @@ Installation consists of 2 parts:
 
 4. Binaries and configuration files will be stored in the bridgeuser's home directory in `poa-bridge` folder, with the following structure:
 ```
-.
 poa-bridge/
-└── bridge
-    ├── bridge
+└── bridge/
+    ├── bridge*
     ├── config.toml
     ├── db.toml
-    ├── ForeignBridge.bin
     ├── foreign-password.txt
-    ├── HomeBridge.bin
     ├── home-password.txt
-    └── keys
-        ├── foreign-keystore.json
-        └── home-keystore.json
+    └── keys/
+       ├── foreign-keystore.json
+       └── home-keystore.json
 ```
 here `*` means executable file, `/` means folder. Parity binary is downloaded both to home-node folder and foreign-node folder in case different versions might be required.
 
@@ -35,7 +32,6 @@ here `*` means executable file, `/` means folder. Parity binary is downloaded bo
 2. Bridge `config.toml` is created based on `roles/bridge/templates/bridge.service.j2`, example:
 ```
 keystore = "keys"
-estimated_gas_cost_of_withdraw = 0
 
 [home]
 account = "0x006E27B6A72E1f34C626762F3C4761547Aff1421"
@@ -46,31 +42,24 @@ rpc_host = "https://sokol.poa.network"
 rpc_port = 443
 password = "home-password.txt"
 
-[home.contract]
-bin = "HomeBridge.bin"
-
 [foreign]
 account = "0x006E27B6A72E1f34C626762F3C4761547Aff1421"
 required_confirmations = 0
 poll_interval = 2
 request_timeout = 360
-rpc_host = "https://kovan.infura.io/metamask"
+rpc_host = "https://kovan.infura.io/mew"
 rpc_port = 443
 password = "foreign-password.txt"
 
-[foreign.contract]
-bin = "ForeignBridge.bin"
-
 [authorities]
 accounts = [
-  "0x006E27B6A72E1f34C626762F3C4761547Aff1421",
-  "0x006E27B6A72E1f34C626762F3C4761547Aff1421"
+  "0xe388c256c31ff953343ce81160b5ca9b564c1a32",
+  "0xbbefa45868cb8d6d445b78592175e4f1049570b0",
+  "0x2822e60af67f3713e696d80281e7e62fc6619dfe"
 ]
 required_signatures = 1
 
 [transactions]
-home_deploy = { gas = 3000000, gas_price = 1000000000 }
-foreign_deploy = { gas = 3000000, gas_price = 1000000000 }
 deposit_relay = { gas = 3000000, gas_price = 1000000000 }
 withdraw_relay = { gas = 3000000, gas_price = 1000000000 }
 withdraw_confirm = { gas = 3000000, gas_price = 1000000000 }
@@ -126,6 +115,15 @@ note if it's reported `active`, `running` or `dead`
 3. Tail bridge logs from `/var/log/syslog`:
 ```
 tail -F /var/log/syslog | grep bridge
+```
+
+4. Relogin as bridge user (user without sudo access for running bridge):
+```
+sudo -i -u bridgeuser
+```
+to go back
+```
+exit
 ```
 
 ## URLs of bridge precompiled binary

--- a/upgradable-wo-parity/NEW-BRIDGE.md
+++ b/upgradable-wo-parity/NEW-BRIDGE.md
@@ -9,39 +9,31 @@ home_rpc_url: https://sokol.poa.network
 home_rpc_port: 443
 
 ### foreign side rpc
-foreign_rpc_url: https://kovan.infura.io/metamask
+foreign_rpc_url: https://kovan.infura.io/mew
 foreign_rpc_port: 443
 
 ### bridge configs
-bridge_estimated_gas_cost_of_withdraw: 0
-bridge_home_deploy_gas: 3000000
-bridge_foreign_deploy_gas: 3000000
-bridge_deposit_relay_gas: 3000000
-bridge_withdraw_relay_gas: 3000000
+bridge_deposit_relay_gas:    3000000
+bridge_withdraw_relay_gas:   3000000
 bridge_withdraw_confirm_gas: 3000000
 
-bridge_home_deploy_gas_price: 1000000000
-bridge_foreign_deploy_gas_price: 1000000000
-bridge_deposit_relay_gas_price: 1000000000
-bridge_withdraw_relay_gas_price: 1000000000
+bridge_deposit_relay_gas_price:    1000000000
+bridge_withdraw_relay_gas_price:   1000000000
 bridge_withdraw_confirm_gas_price: 1000000000
 
 bridge_authorities:
-  - "0x006E27B6A72E1f34C626762F3C4761547Aff1421"
-  - "0x006E27B6A72E1f34C626762F3C4761547Aff1421"
+  - "0xe388c256c31ff953343ce81160b5ca9b564c1a32"
+  - "0xbbefa45868cb8d6d445b78592175e4f1049570b0"
+  - "0x2822e60af67f3713e696d80281e7e62fc6619dfe"
 bridge_authorities_requires_signatures: 1
 
 bridge_home_required_confirmations: 0
-bridge_home_poll_interval: 2
-bridge_home_request_timeout: 360
 bridge_foreign_required_confirmations: 0
-bridge_foreign_poll_interval: 2
-bridge_foreign_request_timeout: 360
 
-bridge_home_contract_address: "0x9A3EE574D3945201064A4CfcE56deed0c576422e"
-bridge_foreign_contract_address: "0x4c4C8BB1ea9d81543764e1e59bEc7773b1Df298e"
-bridge_home_contract_deploy: 2079636
-bridge_foreign_contract_deploy: 6964652
+bridge_home_contract_address: "0x98f7b68C0Ef6A7DA0Bb0E786144A87bfEcc5cbD1"
+bridge_foreign_contract_address: "0x5c29759020Fa2251B6481A3Ac1Ee507Ddbdc075c"
+bridge_home_contract_deploy: 2213129
+bridge_foreign_contract_deploy: 7066466
 ```
 
 Let's examine available options:
@@ -51,6 +43,6 @@ Let's examine available options:
 * `bridge_authorities` should be set to an array of authorities addresses, one per line starting with dash `-`, like this:
 ```
 bridge_authorities:
-  - "0x123..."
-  - "0xabc..."
+  - "0x1234.."
+  - "0xabcd.."
 ```

--- a/upgradable-wo-parity/group_vars/sokol-kovan.yml
+++ b/upgradable-wo-parity/group_vars/sokol-kovan.yml
@@ -28,3 +28,6 @@ bridge_home_contract_address: "0x98f7b68C0Ef6A7DA0Bb0E786144A87bfEcc5cbD1"
 bridge_foreign_contract_address: "0x5c29759020Fa2251B6481A3Ac1Ee507Ddbdc075c"
 bridge_home_contract_deploy: 2213129
 bridge_foreign_contract_deploy: 7066466
+
+bridge_home_poll_interval: 4
+bridge_foreign_poll_interval: 3

--- a/upgradable-wo-parity/group_vars/sokol-kovan.yml
+++ b/upgradable-wo-parity/group_vars/sokol-kovan.yml
@@ -7,17 +7,12 @@ foreign_rpc_url: https://kovan.infura.io/mew
 foreign_rpc_port: 443
 
 ### bridge configs
-bridge_estimated_gas_cost_of_withdraw: 0
-bridge_home_deploy_gas: 3000000
-bridge_foreign_deploy_gas: 3000000
-bridge_deposit_relay_gas: 3000000
-bridge_withdraw_relay_gas: 3000000
+bridge_deposit_relay_gas:    3000000
+bridge_withdraw_relay_gas:   3000000
 bridge_withdraw_confirm_gas: 3000000
 
-bridge_home_deploy_gas_price: 1000000000
-bridge_foreign_deploy_gas_price: 1000000000
-bridge_deposit_relay_gas_price: 1000000000
-bridge_withdraw_relay_gas_price: 1000000000
+bridge_deposit_relay_gas_price:    1000000000
+bridge_withdraw_relay_gas_price:   1000000000
 bridge_withdraw_confirm_gas_price: 1000000000
 
 bridge_authorities:
@@ -27,11 +22,7 @@ bridge_authorities:
 bridge_authorities_requires_signatures: 1
 
 bridge_home_required_confirmations: 0
-bridge_home_poll_interval: 2
-bridge_home_request_timeout: 360
 bridge_foreign_required_confirmations: 0
-bridge_foreign_poll_interval: 2
-bridge_foreign_request_timeout: 360
 
 bridge_home_contract_address: "0x98f7b68C0Ef6A7DA0Bb0E786144A87bfEcc5cbD1"
 bridge_foreign_contract_address: "0x5c29759020Fa2251B6481A3Ac1Ee507Ddbdc075c"

--- a/upgradable-wo-parity/roles/bridge/defaults/main.yml
+++ b/upgradable-wo-parity/roles/bridge/defaults/main.yml
@@ -39,7 +39,7 @@ bridge_keystore_folder: "keys"
 bridge_home_password_file: "home-password.txt"
 bridge_foreign_password_file: "foreign-password.txt"
 
-bridge_home_poll_interval: 2
-bridge_home_request_timeout: 360
-bridge_foreign_poll_interval: 2
-bridge_foreign_request_timeout: 360
+bridge_home_poll_interval: 1
+bridge_home_request_timeout: 5
+bridge_foreign_poll_interval: 1
+bridge_foreign_request_timeout: 5

--- a/upgradable-wo-parity/roles/bridge/defaults/main.yml
+++ b/upgradable-wo-parity/roles/bridge/defaults/main.yml
@@ -4,7 +4,6 @@
 # bridge_bin_url                          (*) url from which to download bridge binary
 # bridge_bin_sha256                       (*) sha256 checksum of the binary
 # bridge_service_name                     (*) name to be used for bridge service
-# bridge_estimated_gas_cost_of_withdraw   bridge config option (used only in templates)
 # bridge_deposit_relay_gas                bridge config option (used only in templates)
 # bridge_withdraw_relay_gas               bridge config option (used only in templates)
 # bridge_withdraw_confirm_gas             bridge config option (used only in templates)
@@ -19,6 +18,10 @@
 # bridge_keystore_folder                  (*) folder to store keystore files
 # bridge_home_password_file               (*) name of the file with password
 # bridge_foreign_password_file            (*) name of the file with password
+# home_rpc_url                            url of home-side rpc endpoint
+# foreign_rpc_url                         url of foreign-sode rpc endpoint
+# home_rpc_port                           port of home-side rpc endpoint
+# foreign_rpc_port                        port of foreign-side rpc endpoint
 #
 ---
 bridge_path: "{{ base_path }}/bridge"
@@ -27,11 +30,16 @@ bridge_bin_sha256: "59405959eeb8b3095543b3e385b8cbb0bf0215a6fc1a40bce65ae9c71ede
 bridge_service_name: "bridge"
 db_toml_location: ""
 
-bridge_home_contract_bytecode: ""
-bridge_foreign_contract_bytecode: ""
+home_rpc_port: 443
+foreign_rpc_port: 443
 
-restart_delay_sec: 3
+restart_delay_sec: 2
 
 bridge_keystore_folder: "keys"
 bridge_home_password_file: "home-password.txt"
 bridge_foreign_password_file: "foreign-password.txt"
+
+bridge_home_poll_interval: 2
+bridge_home_request_timeout: 360
+bridge_foreign_poll_interval: 2
+bridge_foreign_request_timeout: 360

--- a/upgradable-wo-parity/roles/bridge/defaults/main.yml
+++ b/upgradable-wo-parity/roles/bridge/defaults/main.yml
@@ -39,7 +39,5 @@ bridge_keystore_folder: "keys"
 bridge_home_password_file: "home-password.txt"
 bridge_foreign_password_file: "foreign-password.txt"
 
-bridge_home_poll_interval: 1
 bridge_home_request_timeout: 5
-bridge_foreign_poll_interval: 1
 bridge_foreign_request_timeout: 5

--- a/upgradable-wo-parity/roles/bridge/tasks/main.yml
+++ b/upgradable-wo-parity/roles/bridge/tasks/main.yml
@@ -13,30 +13,36 @@
   notify:
     - restart {{ bridge_service_name }}
 
-- name: "Bridge - create file with home contract bytecode"
-  template:
-    src: "HomeBridge.bin.j2"
-    dest: "{{ bridge_path }}/HomeBridge.bin"
-
-- name: "Bridge - create file with foreign contract bytecode"
-  template:
-    src: "ForeignBridge.bin.j2"
-    dest: "{{ bridge_path }}/ForeignBridge.bin"
-
 - name: "Bridge - create keystore folder"
   file:
     path: "{{ bridge_path }}/{{ bridge_keystore_folder }}"
     state: directory
 
-- name: "Bridge - create keystore files"
+# - name: "Bridge - create keystore files"
+#   template:
+#     src: "{{ item }}.j2"
+#     dest: "{{ bridge_path }}/{{ bridge_keystore_folder }}/{{ item }}"
+#   with_items:
+#     - foreign-keystore.json
+#     - home-keystore.json
+#   notify:
+#     - restart bridge
+
+- name: "Bridge - create home keystore file"
   template:
-    src: "{{ item }}.j2"
-    dest: "{{ bridge_path }}/{{ bridge_keystore_folder }}/{{ item }}"
-  with_items:
-    - foreign-keystore.json
-    - home-keystore.json
+    src: "home-keystore.json.j2"
+    dest: "{{ bridge_path }}/{{ bridge_keystore_folder }}/home-keystore.json"
   notify:
     - restart bridge
+
+- name: "Bridge - create foreign keystore file"
+  template:
+    src: "foreign-keystore.json.j2"
+    dest: "{{ bridge_path }}/{{ bridge_keystore_folder }}/foreign-keystore.json"
+  notify:
+    - restart bridge
+  when: home_signer_address != foreign_signer_address
+
 
 - name: "Bridge - create password files"
   template:

--- a/upgradable-wo-parity/roles/bridge/templates/ForeignBridge.bin.j2
+++ b/upgradable-wo-parity/roles/bridge/templates/ForeignBridge.bin.j2
@@ -1,1 +1,0 @@
-{{ bridge_foreign_contract_bytecode }}

--- a/upgradable-wo-parity/roles/bridge/templates/HomeBridge.bin.j2
+++ b/upgradable-wo-parity/roles/bridge/templates/HomeBridge.bin.j2
@@ -1,1 +1,0 @@
-{{ bridge_home_contract_bytecode }}

--- a/upgradable-wo-parity/roles/bridge/templates/config.toml.j2
+++ b/upgradable-wo-parity/roles/bridge/templates/config.toml.j2
@@ -1,5 +1,4 @@
 keystore = "{{ bridge_keystore_folder }}"
-estimated_gas_cost_of_withdraw = {{ bridge_estimated_gas_cost_of_withdraw }}
 
 [home]
 account = "{{ home_signer_address }}"
@@ -10,9 +9,6 @@ rpc_host = "{{ home_rpc_url }}"
 rpc_port = {{ home_rpc_port }}
 password = "{{ bridge_home_password_file }}"
 
-[home.contract]
-bin = "HomeBridge.bin"
-
 [foreign]
 account = "{{ foreign_signer_address }}"
 required_confirmations = {{ bridge_foreign_required_confirmations }}
@@ -22,9 +18,6 @@ rpc_host = "{{ foreign_rpc_url }}"
 rpc_port = {{ foreign_rpc_port }}
 password = "{{ bridge_foreign_password_file }}"
 
-[foreign.contract]
-bin = "ForeignBridge.bin"
-
 [authorities]
 accounts = [
   "{{ bridge_authorities | join ('",\n  "') }}"
@@ -32,8 +25,6 @@ accounts = [
 required_signatures = {{ bridge_authorities_requires_signatures }}
 
 [transactions]
-home_deploy = { gas = {{ bridge_home_deploy_gas }}, gas_price = {{ bridge_home_deploy_gas_price }} }
-foreign_deploy = { gas = {{ bridge_foreign_deploy_gas }}, gas_price = {{ bridge_foreign_deploy_gas_price }} }
 deposit_relay = { gas = {{ bridge_deposit_relay_gas }}, gas_price = {{ bridge_deposit_relay_gas_price }} }
 withdraw_relay = { gas = {{ bridge_withdraw_relay_gas }}, gas_price = {{ bridge_withdraw_relay_gas_price }} }
 withdraw_confirm = { gas = {{ bridge_withdraw_confirm_gas }}, gas_price = {{ bridge_withdraw_confirm_gas_price }} }


### PR DESCRIPTION
Update bridge config file to remove fields that are no longer required,example:

```
keystore = "keys"

[home]
account = "0x006E27B6A72E1f34C626762F3C4761547Aff1421"
required_confirmations = 0
poll_interval = 1
request_timeout = 5
rpc_host = "https://sokol.poa.network"
rpc_port = 443
password = "home-password.txt"

[foreign]
account = "0x006E27B6A72E1f34C626762F3C4761547Aff1421"
required_confirmations = 0
poll_interval = 1
request_timeout = 5
rpc_host = "https://kovan.infura.io/mew"
rpc_port = 443
password = "foreign-password.txt"

[authorities]
accounts = [
  "0xe388c256c31ff953343ce81160b5ca9b564c1a32",
  "0xbbefa45868cb8d6d445b78592175e4f1049570b0",
  "0x2822e60af67f3713e696d80281e7e62fc6619dfe"
]
required_signatures = 1

[transactions]
deposit_relay = { gas = 3000000, gas_price = 1000000000 }
withdraw_relay = { gas = 3000000, gas_price = 1000000000 }
withdraw_confirm = { gas = 3000000, gas_price = 1000000000 }
```

@akolotov  could you please take a look, I might have missed something