### PR TITLE
Common fixes

### DIFF
--- a/upgradable-wo-parity/authority-node.yml
+++ b/upgradable-wo-parity/authority-node.yml
@@ -1,9 +1,6 @@
 ---
 - hosts: all
-  vars:
-    service_user: bridgeuser
+  become: yes
   roles:
     - authority-preconf
-    - role: bridge
-      become: yes
-      become_user: "{{ service_user }}"
+    - bridge

--- a/upgradable-wo-parity/authority-node.yml
+++ b/upgradable-wo-parity/authority-node.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: all
   become: yes
+  gather_facts: no
   roles:
     - authority-preconf
     - bridge

--- a/upgradable-wo-parity/group_vars/all.yml
+++ b/upgradable-wo-parity/group_vars/all.yml
@@ -2,3 +2,5 @@
 base_path: "/home/{{ service_user }}/poa-bridge"
 
 become_method: sudo
+
+service_user: bridgeuser

--- a/upgradable-wo-parity/group_vars/all.yml
+++ b/upgradable-wo-parity/group_vars/all.yml
@@ -1,2 +1,4 @@
 ### global settings
 base_path: "/home/{{ service_user }}/poa-bridge"
+
+become_method: sudo

--- a/upgradable-wo-parity/hosts.yml.template
+++ b/upgradable-wo-parity/hosts.yml.template
@@ -3,6 +3,7 @@ sokol-kovan:
   hosts:
     192.0.2.1:
       ansible_user: ubuntu
+      service_user: bridgeuser
       ansible_python_interpreter: "/usr/bin/python3"
       home_signer_address: ""
       home_signer_keyfile: ''
@@ -11,3 +12,4 @@ sokol-kovan:
       foreign_signer_keyfile: ''
       foreign_signer_password: ""
       syslog_server_port: ""        # only if you want to forward syslog to a special server. format should be server:port
+      custom_ssh_port: ""

--- a/upgradable-wo-parity/hosts.yml.template
+++ b/upgradable-wo-parity/hosts.yml.template
@@ -3,7 +3,6 @@ sokol-kovan:
   hosts:
     192.0.2.1:
       ansible_user: ubuntu
-      service_user: bridgeuser
       ansible_python_interpreter: "/usr/bin/python3"
       home_signer_address: ""
       home_signer_keyfile: ''

--- a/upgradable-wo-parity/roles/authority-preconf/defaults/main.yml
+++ b/upgradable-wo-parity/roles/authority-preconf/defaults/main.yml
@@ -4,3 +4,4 @@
 #
 ---
 syslog_server_port: ""
+custom_ssh_port: ""

--- a/upgradable-wo-parity/roles/authority-preconf/handlers/main.yml
+++ b/upgradable-wo-parity/roles/authority-preconf/handlers/main.yml
@@ -1,21 +1,20 @@
 ---
 - name: restart ufw
-  become: yes
-  become_user: root
   service:
     name: ufw
     state: restarted
 
 - name: restart chrony
-  become: yes
-  become_user: root
   service:
     name: chrony
     state: restarted
 
 - name: restart rsyslog
-  become: true
-  become_user: root
   service:
     name: rsyslog
+    state: restarted
+
+- name: restart sshd
+  service:
+    name: sshd
     state: restarted

--- a/upgradable-wo-parity/roles/authority-preconf/tasks/create-user.yml
+++ b/upgradable-wo-parity/roles/authority-preconf/tasks/create-user.yml
@@ -1,9 +1,5 @@
 ---
 - name: Preconf.Create user
-  become: yes
-  become_user: root
   user:
     name: "{{ service_user }}"
-    groups: ""
     shell: "/bin/bash"
-    append: yes

--- a/upgradable-wo-parity/roles/authority-preconf/tasks/main.yml
+++ b/upgradable-wo-parity/roles/authority-preconf/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: Check if remote computer is listening standard ssh port
+  become: no
   wait_for: port="{{ ansible_port | default(22) }}" state="started" host="{{ inventory_hostname }}" connect_timeout="3" timeout="4" 
   delegate_to: "localhost" 
   ignore_errors: "yes"

--- a/upgradable-wo-parity/roles/authority-preconf/tasks/main.yml
+++ b/upgradable-wo-parity/roles/authority-preconf/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Preconf - sshd
+  import_tasks: sshd.yml
+  when: custom_ssh_port != ""
+
 - name: Preconf - create user
   import_tasks: create-user.yml
 
@@ -7,6 +11,7 @@
 
 - name: Preconf - configure syslog forwarding
   import_tasks: syslog-forward.yml
+  when: syslog_server_port != ""
 
 - name: Preconf - run handlers immediately
   meta: flush_handlers

--- a/upgradable-wo-parity/roles/authority-preconf/tasks/main.yml
+++ b/upgradable-wo-parity/roles/authority-preconf/tasks/main.yml
@@ -1,13 +1,23 @@
 ---
+- name: Check if remote computer is listening standard ssh port
+  wait_for: port="{{ ansible_port | default(22) }}" state="started" host="{{ inventory_hostname }}" connect_timeout="3" timeout="4" 
+  delegate_to: "localhost" 
+  ignore_errors: "yes"
+  register: port_used
+
+- name: Set inventory ansible_port to custom
+  set_fact: ansible_port="{{ custom_ssh_port }}"
+  when: port_used.state is undefined
+  
+- name: Preconf - setup UFW firewall
+  import_tasks: ufw.yml
+
 - name: Preconf - sshd
   import_tasks: sshd.yml
-  when: custom_ssh_port != ""
+  when: custom_ssh_port != ""  and custom_ssh_port != ansible_port | default(22)
 
 - name: Preconf - create user
   import_tasks: create-user.yml
-
-- name: Preconf - setup UFW firewall
-  import_tasks: ufw.yml
 
 - name: Preconf - configure syslog forwarding
   import_tasks: syslog-forward.yml

--- a/upgradable-wo-parity/roles/authority-preconf/tasks/sshd.yml
+++ b/upgradable-wo-parity/roles/authority-preconf/tasks/sshd.yml
@@ -10,6 +10,7 @@
   meta: flush_handlers
   
 - name: Doublecheck if computer is listening custom SSH port before removing 22 port access
+  become: no
   wait_for: port="{{ custom_ssh_port }}" state="started" host="{{ inventory_hostname }}" connect_timeout="3" timeout="4" 
   delegate_to: "localhost" 
   register: port_used

--- a/upgradable-wo-parity/roles/authority-preconf/tasks/sshd.yml
+++ b/upgradable-wo-parity/roles/authority-preconf/tasks/sshd.yml
@@ -1,24 +1,29 @@
-- name: Check if remote computer is listening standard ssh port
-  wait_for: port="22" state="started" host="{{ inventory_hostname }}" connect_timeout="3" timeout="4" 
-  delegate_to: "localhost" 
-  ignore_errors: "yes"
-  register: port_used
-
-- name: Set inventory ansible_port to default
-  set_fact: ansible_port="22"
-  when: port_used.state is defined
-  
-- name: Set inventory ansible_port to custom
-  set_fact: ansible_port="{{ custom_ssh_port }}"
-  when: port_used.state is undefined
-
 - name: Setup new SSH port
   lineinfile:
     dest: "/etc/ssh/sshd_config"
     regexp: "^Port"
     line: "Port {{ custom_ssh_port }}"
-  when: ansible_port != custom_ssh_port
+  register: old_port=ansible_port
   notify: restart sshd
   
 - name: Preconf - run handlers immediately
   meta: flush_handlers
+  
+- name: Doublecheck if computer is listening custom SSH port before removing 22 port access
+  wait_for: port="{{ custom_ssh_port }}" state="started" host="{{ inventory_hostname }}" connect_timeout="3" timeout="4" 
+  delegate_to: "localhost" 
+  register: port_used
+
+- name: Preconf.UFW - remove default ssh access
+  ufw:
+    delete: yes
+    rule: "allow"
+    port: "{{ old_port | default(22) }}"
+    proto: "tcp"
+  when: port_used is defined
+  notify:
+    - restart ufw
+    
+- name: Set inventory ansible_port to custom
+  set_fact: ansible_port="{{ custom_ssh_port }}"
+  

--- a/upgradable-wo-parity/roles/authority-preconf/tasks/sshd.yml
+++ b/upgradable-wo-parity/roles/authority-preconf/tasks/sshd.yml
@@ -1,10 +1,16 @@
 - name: Check if remote computer is listening standard ssh port
-  wait_for: port="22" state="started" host="{{ inventory_hostname }}" connect_timeout="5" timeout="10" delegate_to="localhost" ignore_errors="yes"
+  wait_for: port="22" state="started" host="{{ inventory_hostname }}" connect_timeout="3" timeout="4" 
+  delegate_to: "localhost" 
+  ignore_errors: "yes"
   register: port_used
 
 - name: Set inventory ansible_port to default
   set_fact: ansible_port="22"
-  when: port_used.state == "started"
+  when: port_used.state is defined
+  
+- name: Set inventory ansible_port to custom
+  set_fact: ansible_port="{{ custom_ssh_port }}"
+  when: port_used.state is undefined
 
 - name: Setup new SSH port
   lineinfile:
@@ -16,6 +22,3 @@
   
 - name: Preconf - run handlers immediately
   meta: flush_handlers
-
-- name: Change ansible port for
-  set_fact: ansible_port="{{ custom_ssh_port }}"

--- a/upgradable-wo-parity/roles/authority-preconf/tasks/sshd.yml
+++ b/upgradable-wo-parity/roles/authority-preconf/tasks/sshd.yml
@@ -1,0 +1,21 @@
+- name: Check if remote computer is listening standard ssh port
+  wait_for: port="22" state="started" host="{{ inventory_hostname }}" connect_timeout="5" timeout="10" delegate_to="localhost" ignore_errors="yes"
+  register: port_used
+
+- name: Set inventory ansible_port to default
+  set_fact: ansible_port="22"
+  when: port_used.state == "started"
+
+- name: Setup new SSH port
+  lineinfile:
+    dest: "/etc/ssh/sshd_config"
+    regexp: "^Port"
+    line: "Port {{ custom_ssh_port }}"
+  when: ansible_port != custom_ssh_port
+  notify: restart sshd
+  
+- name: Preconf - run handlers immediately
+  meta: flush_handlers
+
+- name: Change ansible port for
+  set_fact: ansible_port="{{ custom_ssh_port }}"

--- a/upgradable-wo-parity/roles/authority-preconf/tasks/syslog-forward.yml
+++ b/upgradable-wo-parity/roles/authority-preconf/tasks/syslog-forward.yml
@@ -12,9 +12,6 @@
 #       notify: restart rsyslog
 
 - name: Preconf.Syslog forward
-  become: yes
-  become_user: root
-  when: syslog_server_port != ""
   block:
     - name: Preconf.Syslog forward - add lines to /etc/rsyslog.conf
       blockinfile:

--- a/upgradable-wo-parity/roles/authority-preconf/tasks/ufw.yml
+++ b/upgradable-wo-parity/roles/authority-preconf/tasks/ufw.yml
@@ -24,23 +24,19 @@
           policy: "deny"
         - direction: "outgoing"
           policy: "allow"
-      notify:
-        - restart ufw
 
     - name: Preconf.UFW - allow ssh access
       ufw:
         rule: "allow"
-        port: "{{ ansible_ssh_port|default(22) }}"
+        port: "{{ ansible_port|default(22) }}"
         proto: "tcp"
-      notify:
-        - restart ufw
 
     - name: Preconf.UFW - disable logging
       ufw:
         logging: off
-      notify:
-        - restart ufw
 
     - name: Preconf.UFW - enable ufw to start on boot
       ufw:
         state: enabled
+      notify:
+        - restart ufw

--- a/upgradable-wo-parity/roles/authority-preconf/tasks/ufw.yml
+++ b/upgradable-wo-parity/roles/authority-preconf/tasks/ufw.yml
@@ -3,8 +3,6 @@
 
 ---
 - name: UFW
-  become: yes
-  become_user: root
   block:
     - name: Preconf.UFW - install ufw
       package:

--- a/upgradable-wo-parity/roles/authority-preconf/tasks/ufw.yml
+++ b/upgradable-wo-parity/roles/authority-preconf/tasks/ufw.yml
@@ -28,7 +28,7 @@
     - name: Preconf.UFW - allow ssh access
       ufw:
         rule: "allow"
-        port: "{{ ansible_port|default(22) }}"
+        port: "{{ ansible_port | default(22) }}"
         proto: "tcp"
 
     - name: Preconf.UFW - disable logging

--- a/upgradable-wo-parity/roles/authority-preconf/tasks/ufw.yml
+++ b/upgradable-wo-parity/roles/authority-preconf/tasks/ufw.yml
@@ -28,6 +28,13 @@
         rule: "allow"
         port: "{{ ansible_port | default(22) }}"
         proto: "tcp"
+    
+    - name: Preconf.UFW - allow custom port access
+      ufw:
+        rule: "allow"
+        port: "{{ custom_ssh_port }}"
+        proto: "tcp"
+      when: custom_ssh_port!="" and  custom_ssh_port!=(ansible_port|default(22))
 
     - name: Preconf.UFW - disable logging
       ufw:

--- a/upgradable-wo-parity/roles/bridge/handlers/main.yml
+++ b/upgradable-wo-parity/roles/bridge/handlers/main.yml
@@ -1,7 +1,5 @@
 ---
 - name: "restart {{ bridge_service_name }}"
-  become: yes
-  become_user: root
   service:
     name: "{{ bridge_service_name }}"
     state: restarted

--- a/upgradable-wo-parity/roles/bridge/tasks/main.yml
+++ b/upgradable-wo-parity/roles/bridge/tasks/main.yml
@@ -40,7 +40,7 @@
   template:
     src: "home-keystore.json.j2"
     dest: "{{ bridge_path }}/{{ bridge_keystore_folder }}/home-keystore.json"
-    mode: 0700
+    mode: 0600
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
   notify:
@@ -50,7 +50,7 @@
   template:
     src: "foreign-keystore.json.j2"
     dest: "{{ bridge_path }}/{{ bridge_keystore_folder }}/foreign-keystore.json"
-    mode: 0700
+    mode: 0600
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
   notify:
@@ -62,7 +62,7 @@
   template:
     src: "{{ item }}.j2"
     dest: "{{ bridge_path }}/{{ item }}"
-    mode: 0700
+    mode: 0600
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
   with_items:
@@ -75,7 +75,7 @@
   template:
     src: config.toml.j2
     dest: "{{ bridge_path }}/config.toml"
-    mode: 0700
+    mode: 0600
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
   notify:
@@ -85,7 +85,7 @@
   template:
     src: "db.toml.j2"
     dest: "{{ bridge_path }}/db.toml"
-    mode: 0700
+    mode: 0600
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
     force: no
@@ -98,7 +98,7 @@
     force: no
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
-    mode: 0700
+    mode: 0600
   when: db_toml_location != ""
 
 - name: "Bridge - install bridge service"
@@ -110,6 +110,9 @@
     mode: 0644
   notify:
     - restart {{ bridge_service_name }}
+
+- name: "Bridge - enable bridge service to start at boot"
+  command: "systemctl enable {{ bridge_service_name }}.service"
 
 - name: "Bridge - ensure bridge service is running"
   systemd:

--- a/upgradable-wo-parity/roles/bridge/tasks/main.yml
+++ b/upgradable-wo-parity/roles/bridge/tasks/main.yml
@@ -3,6 +3,9 @@
   file:
     path: "{{ bridge_path }}"
     state: directory
+    mode: 0755
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
 
 - name: "Bridge - download bridge binary"
   get_url:
@@ -17,6 +20,9 @@
   file:
     path: "{{ bridge_path }}/{{ bridge_keystore_folder }}"
     state: directory
+    mode: 0500
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
 
 # - name: "Bridge - create keystore files"
 #   template:
@@ -32,6 +38,9 @@
   template:
     src: "home-keystore.json.j2"
     dest: "{{ bridge_path }}/{{ bridge_keystore_folder }}/home-keystore.json"
+    mode: 0400
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
   notify:
     - restart bridge
 
@@ -39,6 +48,9 @@
   template:
     src: "foreign-keystore.json.j2"
     dest: "{{ bridge_path }}/{{ bridge_keystore_folder }}/foreign-keystore.json"
+    mode: 0400
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
   notify:
     - restart bridge
   when: home_signer_address != foreign_signer_address
@@ -48,6 +60,9 @@
   template:
     src: "{{ item }}.j2"
     dest: "{{ bridge_path }}/{{ item }}"
+    mode: 0400
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
   with_items:
     - foreign-password.txt
     - home-password.txt
@@ -58,6 +73,9 @@
   template:
     src: config.toml.j2
     dest: "{{ bridge_path }}/config.toml"
+    mode: 0400
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
   notify:
     - restart bridge
 
@@ -65,6 +83,9 @@
   template:
     src: "db.toml.j2"
     dest: "{{ bridge_path }}/db.toml"
+    mode: 0400
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
     force: no
   when: db_toml_location == ""
 
@@ -75,27 +96,20 @@
     force: no
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
+    mode: 0400
   when: db_toml_location != ""
 
 - name: "Bridge - install bridge service"
-  become: yes
-  become_user: root
   template:
     src: bridge.service.j2
     dest: /etc/systemd/system/{{ bridge_service_name }}.service
     owner: root
     group: root
+    mode: 0755
   notify:
     - restart {{ bridge_service_name }}
 
-- name: "Bridge - enable bridge service to start at boot"
-  become: yes
-  become_user: root
-  command: "systemctl enable {{ bridge_service_name }}.service"
-
 - name: "Bridge - ensure bridge service is running"
-  become: yes
-  become_user: root
   systemd:
     name: "{{ bridge_service_name }}.service"
     state: started

--- a/upgradable-wo-parity/roles/bridge/tasks/main.yml
+++ b/upgradable-wo-parity/roles/bridge/tasks/main.yml
@@ -3,7 +3,7 @@
   file:
     path: "{{ bridge_path }}"
     state: directory
-    mode: 0500
+    mode: 0700
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
 
@@ -12,7 +12,9 @@
     url: "{{ bridge_bin_url }}"
     checksum: "sha256:{{ bridge_bin_sha256 }}"
     dest: "{{ bridge_path }}/bridge"
-    mode: "0500"
+    mode: "0700"
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
   notify:
     - restart {{ bridge_service_name }}
 
@@ -20,7 +22,7 @@
   file:
     path: "{{ bridge_path }}/{{ bridge_keystore_folder }}"
     state: directory
-    mode: 0500
+    mode: 0700
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
 
@@ -38,7 +40,7 @@
   template:
     src: "home-keystore.json.j2"
     dest: "{{ bridge_path }}/{{ bridge_keystore_folder }}/home-keystore.json"
-    mode: 0400
+    mode: 0700
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
   notify:
@@ -48,7 +50,7 @@
   template:
     src: "foreign-keystore.json.j2"
     dest: "{{ bridge_path }}/{{ bridge_keystore_folder }}/foreign-keystore.json"
-    mode: 0400
+    mode: 0700
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
   notify:
@@ -60,7 +62,7 @@
   template:
     src: "{{ item }}.j2"
     dest: "{{ bridge_path }}/{{ item }}"
-    mode: 0400
+    mode: 0700
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
   with_items:
@@ -73,7 +75,7 @@
   template:
     src: config.toml.j2
     dest: "{{ bridge_path }}/config.toml"
-    mode: 0400
+    mode: 0700
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
   notify:
@@ -83,7 +85,7 @@
   template:
     src: "db.toml.j2"
     dest: "{{ bridge_path }}/db.toml"
-    mode: 0600
+    mode: 0700
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
     force: no
@@ -96,7 +98,7 @@
     force: no
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
-    mode: 0600
+    mode: 0700
   when: db_toml_location != ""
 
 - name: "Bridge - install bridge service"
@@ -105,7 +107,7 @@
     dest: /etc/systemd/system/{{ bridge_service_name }}.service
     owner: root
     group: root
-    mode: 0755
+    mode: 0644
   notify:
     - restart {{ bridge_service_name }}
 

--- a/upgradable-wo-parity/roles/bridge/tasks/main.yml
+++ b/upgradable-wo-parity/roles/bridge/tasks/main.yml
@@ -3,7 +3,7 @@
   file:
     path: "{{ bridge_path }}"
     state: directory
-    mode: 0755
+    mode: 0500
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
 
@@ -12,7 +12,7 @@
     url: "{{ bridge_bin_url }}"
     checksum: "sha256:{{ bridge_bin_sha256 }}"
     dest: "{{ bridge_path }}/bridge"
-    mode: "0755"
+    mode: "0500"
   notify:
     - restart {{ bridge_service_name }}
 
@@ -83,7 +83,7 @@
   template:
     src: "db.toml.j2"
     dest: "{{ bridge_path }}/db.toml"
-    mode: 0400
+    mode: 0600
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
     force: no
@@ -96,7 +96,7 @@
     force: no
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
-    mode: 0400
+    mode: 0600
   when: db_toml_location != ""
 
 - name: "Bridge - install bridge service"


### PR DESCRIPTION
(#13) `append` set to `no`, so now `service_user` will have only `service_user` group
(#12) `sshd.yml` playbook in the `preconf` role will automatically change ansible ssh port if `custom_ssh_port` variable is provided
(#11) now only one restart is scheduled
(#9) Now all tasks are executed as root, but all files set with proper permissions
(#8) File permissions now explicitly set