### PR TITLE
Use same signer on both sides of bridge

### DIFF
--- a/upgradable-wo-parity/DETAILS.md
+++ b/upgradable-wo-parity/DETAILS.md
@@ -8,7 +8,7 @@ Installation consists of 2 parts:
 
 2. UFW is configured to allow inbound tcp connections only on ssh port (`22` by default)
 
-3. Syslog forwarding to remote server is setup by editing `/etc/rsyslog.conf` file. This is done only if `syslog_server_port` is not empty
+3. Syslog forwarding to remote server is setup by placing a config file in `/etc/rsyslog.d/tls-client.conf` file. This is done only if `syslog_server_port` is not empty
 
 4. Binaries and configuration files will be stored in the bridgeuser's home directory in `poa-bridge` folder, with the following structure:
 ```
@@ -17,10 +17,8 @@ poa-bridge/
     ├── bridge*
     ├── config.toml
     ├── db.toml
-    ├── foreign-password.txt
-    ├── home-password.txt
+    ├── password.txt
     └── keys/
-       ├── foreign-keystore.json
        └── home-keystore.json
 ```
 here `*` means executable file, `/` means folder. Parity binary is downloaded both to home-node folder and foreign-node folder in case different versions might be required.
@@ -38,7 +36,7 @@ required_confirmations = 0
 poll_interval = 2
 rpc_host = "https://sokol.poa.network"
 rpc_port = 443
-password = "home-password.txt"
+password = "password.txt"
 
 [foreign]
 account = "0x006E27B6A72E1f34C626762F3C4761547Aff1421"
@@ -46,7 +44,7 @@ required_confirmations = 0
 poll_interval = 2
 rpc_host = "https://kovan.infura.io/mew"
 rpc_port = 443
-password = "foreign-password.txt"
+password = "password.txt"
 
 [authorities]
 accounts = []

--- a/upgradable-wo-parity/README.md
+++ b/upgradable-wo-parity/README.md
@@ -24,12 +24,8 @@ This file contains parameters specific to your node, so you need to edit it and 
 * `192.0.2.1` - replace with your node's IP address
 * `ansible_user` - user to ssh into your node. Usually it's either `ubuntu` or `root`
 * `ansible_python_interpreter` - path to python interpreter on your node. With Ubuntu 16.04 this should work with default value, however if running the playbook you get an error that `python3` is not found, try changing this to `/usr/bin/python`
-* `home_signer_address` - set this to address (`"0x..."`) of the authority on the home side of the bridge
-* `home_signer_keyfile` - copy json content (`'{...}'`) of authority's keystore file
-* `home_signer_password` - set this to authority's password
-* `foreign_signer_address` - set this to address (`"0x..."`) of the authority on the foreign side of the bridge
-* `foreign_signer_keyfile` - copy json content (`'{...}'`) of authority's keystore file
-* `foreign_signer_password` - set this to authority's password
+* `signer_keyfile` - copy json content (`'{...}'`) of authority's keystore file
+* `signer_password` - set this to authority's password
 * `syslog_server_port` - set this to `server:port` of syslog server (should be provided to you)
 
 ### Installing the node

--- a/upgradable-wo-parity/authority-node.yml
+++ b/upgradable-wo-parity/authority-node.yml
@@ -2,6 +2,15 @@
 - hosts: all
   become: yes
   gather_facts: no
+  vars:
+    home_signer_address: "0x{{ (signer_keyfile|from_json).address }}"
+    home_signer_keyfile: '{{ signer_keyfile }}'
+    home_signer_password: "{{ signer_password }}"
+    foreign_signer_address: "{{ home_signer_address }}"
+    foreign_signer_keyfile: '{{ home_signer_keyfile }}'
+    foreign_signer_password: "{{ home_signer_password }}"
+    bridge_home_password_file: "password.txt"
+    bridge_foreign_password_file: "password.txt"
   roles:
     - authority-preconf
     - bridge

--- a/upgradable-wo-parity/hosts.yml.template
+++ b/upgradable-wo-parity/hosts.yml.template
@@ -4,10 +4,6 @@ core-foundation:
     192.0.2.1:
       ansible_user: ubuntu
       ansible_python_interpreter: "/usr/bin/python3"
-      home_signer_address: ""
-      home_signer_keyfile: ''
-      home_signer_password: ""
-      foreign_signer_address: ""
-      foreign_signer_keyfile: ''
-      foreign_signer_password: ""
+      signer_keyfile: ''
+      signer_password: ""
       syslog_server_port: ""        # this value should be provided to you

--- a/upgradable-wo-parity/roles/authority-preconf/templates/rsyslog-tls-client.conf.j2
+++ b/upgradable-wo-parity/roles/authority-preconf/templates/rsyslog-tls-client.conf.j2
@@ -3,4 +3,4 @@ $ActionSendStreamDriver gtls
 $ActionSendStreamDriverMode 1
 $ActionSendStreamDriverAuthMode x509/name
 $ActionSendStreamDriverPermittedPeer *.papertrailapp.com
-*.*    (o)@@{{ syslog_server_port }}
+*.*    @@{{ syslog_server_port }}

--- a/upgradable-wo-parity/roles/bridge/tasks/main.yml
+++ b/upgradable-wo-parity/roles/bridge/tasks/main.yml
@@ -46,6 +46,16 @@
   notify:
     - restart bridge
 
+- name: "Bridge - create home password file"
+  template:
+    src: "home-password.txt.j2"
+    dest: "{{ bridge_path }}/{{ bridge_home_password_file }}"
+    mode: 0600
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
+  notify:
+    - restart bridge
+
 - name: "Bridge - create foreign keystore file"
   template:
     src: "foreign-keystore.json.j2"
@@ -57,19 +67,16 @@
     - restart bridge
   when: home_signer_address != foreign_signer_address
 
-
-- name: "Bridge - create password files"
+- name: "Bridge - create home password file"
   template:
-    src: "{{ item }}.j2"
-    dest: "{{ bridge_path }}/{{ item }}"
+    src: "foreign-password.txt.j2"
+    dest: "{{ bridge_path }}/{{ bridge_foreign_password_file }}"
     mode: 0600
     owner: "{{ service_user }}"
     group: "{{ service_user }}"
-  with_items:
-    - foreign-password.txt
-    - home-password.txt
   notify:
     - restart bridge
+  when: bridge_home_password_file != bridge_foreign_password_file
 
 - name: "Bridge - create bridge config"
   template:

--- a/upgradable-wo-parity/roles/bridge/templates/foreign-keystore.json.j2
+++ b/upgradable-wo-parity/roles/bridge/templates/foreign-keystore.json.j2
@@ -1,1 +1,1 @@
-{{ foreign_signer_keyfile }}
+{{ foreign_signer_keyfile|to_json }}

--- a/upgradable-wo-parity/roles/bridge/templates/home-keystore.json.j2
+++ b/upgradable-wo-parity/roles/bridge/templates/home-keystore.json.j2
@@ -1,1 +1,1 @@
-{{ home_signer_keyfile }}
+{{ home_signer_keyfile|to_json }}


### PR DESCRIPTION
Simplify hosts.yml by using the same signer account on both sides of the bridge.
Also, extract signer address from keystore.
Closes #17 
Closes #18 