### PR TITLE
Drop gas price parameters

### DIFF
--- a/upgradable-wo-parity/group_vars/core-foundation.yml
+++ b/upgradable-wo-parity/group_vars/core-foundation.yml
@@ -7,8 +7,8 @@ foreign_rpc_url: https://bridge-mainnet-rpc.poa.net
 foreign_rpc_port: 443
 
 ### bridge configs
-bridge_deposit_relay_gas:    300000
-bridge_withdraw_relay_gas:   300000
+bridge_deposit_relay_gas:    150000
+bridge_withdraw_relay_gas:   100000
 bridge_withdraw_confirm_gas: 300000
 
 bridge_deposit_relay_gas_price:    21000000000

--- a/upgradable-wo-parity/group_vars/core-foundation.yml
+++ b/upgradable-wo-parity/group_vars/core-foundation.yml
@@ -7,9 +7,9 @@ foreign_rpc_url: https://bridge-mainnet-rpc.poa.net
 foreign_rpc_port: 443
 
 ### bridge configs
-bridge_deposit_relay_gas:    3000000
-bridge_withdraw_relay_gas:   3000000
-bridge_withdraw_confirm_gas: 3000000
+bridge_deposit_relay_gas:    300000
+bridge_withdraw_relay_gas:   300000
+bridge_withdraw_confirm_gas: 300000
 
 bridge_deposit_relay_gas_price:    21000000000
 bridge_withdraw_relay_gas_price:    1000000000

--- a/upgradable-wo-parity/group_vars/core-foundation.yml
+++ b/upgradable-wo-parity/group_vars/core-foundation.yml
@@ -11,10 +11,6 @@ bridge_deposit_relay_gas:    150000
 bridge_withdraw_relay_gas:   100000
 bridge_withdraw_confirm_gas: 300000
 
-bridge_deposit_relay_gas_price:    21000000000
-bridge_withdraw_relay_gas_price:    1000000000
-bridge_withdraw_confirm_gas_price: 21000000000
-
 bridge_authorities_requires_signatures: 2
 
 bridge_home_required_confirmations: 8

--- a/upgradable-wo-parity/group_vars/sokol-kovan.yml
+++ b/upgradable-wo-parity/group_vars/sokol-kovan.yml
@@ -11,10 +11,6 @@ bridge_deposit_relay_gas:    3000000
 bridge_withdraw_relay_gas:   3000000
 bridge_withdraw_confirm_gas: 3000000
 
-bridge_deposit_relay_gas_price:    1000000000
-bridge_withdraw_relay_gas_price:   1000000000
-bridge_withdraw_confirm_gas_price: 1000000000
-
 bridge_authorities_requires_signatures: 1
 
 bridge_home_required_confirmations: 0

--- a/upgradable-wo-parity/roles/bridge/templates/config.toml.j2
+++ b/upgradable-wo-parity/roles/bridge/templates/config.toml.j2
@@ -27,6 +27,6 @@ accounts = []
 required_signatures = {{ bridge_authorities_requires_signatures }}
 
 [transactions]
-deposit_relay = { gas = {{ bridge_deposit_relay_gas }}, gas_price = {{ bridge_deposit_relay_gas_price }} }
-withdraw_relay = { gas = {{ bridge_withdraw_relay_gas }}, gas_price = {{ bridge_withdraw_relay_gas_price }} }
-withdraw_confirm = { gas = {{ bridge_withdraw_confirm_gas }}, gas_price = {{ bridge_withdraw_confirm_gas_price }} }
+deposit_relay = { gas = {{ bridge_deposit_relay_gas }} }
+withdraw_relay = { gas = {{ bridge_withdraw_relay_gas }} }
+withdraw_confirm = { gas = {{ bridge_withdraw_confirm_gas }} }


### PR DESCRIPTION
Remove unnecessary `*_gas_price` parameters from config section.
Closes #23 