### PR TITLE
Add optional parameter in hosts.yml to rewrite initial block numbers

### DIFF
--- a/upgradable-wo-parity/README.md
+++ b/upgradable-wo-parity/README.md
@@ -28,6 +28,12 @@ This file contains parameters specific to your node, so you need to edit it and 
 * `signer_password` - set this to authority's password
 * `syslog_server_port` - set this to `server:port` of syslog server (should be provided to you)
 
+If you're a new validator joining an existing bridge setup, you may want to additionally set the following parametrs in `hosts.yml`:
+* `last_checked_deposit_relay`
+* `last_checked_withdraw_relay`
+* `last_checked_withdraw_confirm`
+If set, these values overwrite initial block numbers in `db.toml`, so that your node won't be re-processing transactions that are already processed by existing validators. You should get exact values from other validators before running the playbook.
+
 ### Installing the node
 1. If ssh user can't execute `sudo` without password, you will need to add `--ask-become-pass` option below (without `[]` brackets) and provide sudo password when prompted by the playbook.
 2. Run the playbook

--- a/upgradable-wo-parity/hosts.yml.template
+++ b/upgradable-wo-parity/hosts.yml.template
@@ -7,3 +7,7 @@ core-foundation:
       signer_keyfile: ''
       signer_password: ""
       syslog_server_port: ""        # this value should be provided to you
+
+      # last_checked_deposit_relay: 1       # optional value, consult README
+      # last_checked_withdraw_relay: 1      # optional value, consult README
+      # last_checked_withdraw_confirm: 1    # optional value, consult README

--- a/upgradable-wo-parity/roles/bridge/templates/db.toml.j2
+++ b/upgradable-wo-parity/roles/bridge/templates/db.toml.j2
@@ -1,5 +1,5 @@
 home_contract_address = "{{ bridge_home_contract_address }}"
 foreign_contract_address = "{{ bridge_foreign_contract_address }}"
-checked_deposit_relay = {{ bridge_home_contract_deploy }}
-checked_withdraw_relay = {{ bridge_foreign_contract_deploy }}
-checked_withdraw_confirm = {{ bridge_foreign_contract_deploy }}
+checked_deposit_relay = {{ last_checked_deposit_relay|default(bridge_home_contract_deploy) }}
+checked_withdraw_relay = {{ last_checked_withdraw_relay|default(bridge_foreign_contract_deploy) }}
+checked_withdraw_confirm = {{ last_checked_withdraw_confirm|default(bridge_foreign_contract_deploy) }}


### PR DESCRIPTION
Introduce `last_checked_deposit_relay`, `last_checked_withdraw_relay`, `last_checked_withdraw_confirm` parameters set in `hosts.yml` to overwrite corresponding initial block numbers in `db.toml`
If unset, defaults to block numbers of contract deployments from `group_vars/$BRIDGE.yml`.

Only applies if `db.toml` doesn't already exist.

Update `README` and `hosts.yml.example`

Closes #25