### PR TITLE
Fix bug with incorrect options set while calling the functions inside docker container

### DIFF
--- a/bridge-nodejs/roles/post_config/tasks/main.yml
+++ b/bridge-nodejs/roles/post_config/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Get blocks
   become_user: "{{ compose_service_user }}" 
-  shell: docker-compose run bridge_affirmation --entrypoint "node scripts/getValidatorStartBlocks.js"
+  shell: docker-compose run --entrypoint "node scripts/getValidatorStartBlocks.js" bridge_affirmation
   args:
     chdir: "{{ bridge_path }}"
   register: BLOCKS
@@ -15,7 +15,7 @@
 
 - name: Get validator address
   become_user: "{{ compose_service_user }}" 
-  shell: docker-compose run -e VALIDATOR_ADDRESS_PRIVATE_KEY="{{ VALIDATOR_ADDRESS_PRIVATE_KEY }}" bridge_affirmation --entrypoint "node scripts/privateKeyToAddress.js"
+  shell: docker-compose run -e VALIDATOR_ADDRESS_PRIVATE_KEY="{{ VALIDATOR_ADDRESS_PRIVATE_KEY }}" --entrypoint "node scripts/privateKeyToAddress.js" bridge_affirmation
   args:
     chdir: "{{ bridge_path }}"
   register: VADDRESS


### PR DESCRIPTION
According to manual of `docker-compose`:
```
docker-compose [-f <arg>...] [options] [COMMAND]
```
Options should go before arguments, otherwise they are ignored.